### PR TITLE
remove graphviz dependency

### DIFF
--- a/nf_core/pipeline-template/nextflow.config
+++ b/nf_core/pipeline-template/nextflow.config
@@ -143,7 +143,7 @@ trace {
 }
 dag {
   enabled = true
-  file = "${params.tracedir}/pipeline_dag.svg"
+  file = "${params.tracedir}/pipeline_dag.html"
 }
 
 manifest {


### PR DESCRIPTION
The current default DAG image format SVG requires Graphviz. Using the HTML version removes the Graphviz dependency.

It is now common to see the Warning about the missing Graphviz dependency when running nf-core pipelines. In my limited experience it is often the only warning and often not a very useful at that because the DAG is not a main product of th pipeline in most use cases.

The ability to have a DAG output that can be viewed by any computer with a browser and most computers do have one. If you can view an image on a computer it most probably also can render a HTML website.

Because this dependency is on the host system rather than in a container, this means the hassle of installation is left with the user. A big part of Nextflow/nf-core is that it abstracts installations away from users. I consider the Graphviz dependency a clear anti-pattern for Nextflow and nf-core.

Because this makes life easier for users, no additional docs are needed.

This PR arouse out of me seeing "WARN: To render the execution DAG in the required format it is required to install Graphviz -- See http://www.graphviz.org/ for more info." and the discussion on [Slack](https://nfcore.slack.com/archives/CE56GDKN0/p1649703103431669) that followed.

<!--
Many thanks for contributing to nf-core/tools!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a release.

Learn more about contributing: https://github.com/nf-core/tools/tree/master/.github/CONTRIBUTING.md
-->

## PR checklist

- [x] This comment contains a description of changes (with reason)
- [ ] `CHANGELOG.md` is updated
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Documentation in `docs` is updated
